### PR TITLE
Set language dialect if available

### DIFF
--- a/autoload/guesslang.vim
+++ b/autoload/guesslang.vim
@@ -39,7 +39,7 @@ function! guesslang#guesslang() abort
     endfor
   endif
 
-  let lang_pattern = '^\a\a'
+  let lang_pattern = '^\a\a\(_\a\a\)\?'
   let lang = tolower(matchstr(lang, lang_pattern))
   return lang
 endfunction


### PR DESCRIPTION
Do not set spelllang to 'en' for 'en_US' in guesslang_langs, i.e., also
pass the language dialect to spelllang.