### PR TITLE
Fix dict key lookup

### DIFF
--- a/autoload/detectspelllang.vim
+++ b/autoload/detectspelllang.vim
@@ -7,7 +7,7 @@ function! detectspelllang#detectspelllang() abort
 
   let opts = []
   if exists('g:detectspelllang_ftoptions.' . g:detectspelllang_program)
-    exe 'let ftoptions = g:detectspelllang_ftoptions.' . g:detectspelllang_program
+    let ftoptions = g:detectspelllang_ftoptions[g:detectspelllang_program]
     for filetype in keys(ftoptions)
       if &l:filetype is# filetype
         let opts = get(ftoptions, filetype, '')
@@ -21,7 +21,7 @@ function! detectspelllang#detectspelllang() abort
     let lines = filter(lines, 'v:val =~# "\\v(^|[[:space:]])[[:lower:][:upper:]]{2,}[[:space:]][[:lower:][:upper:]]"')
   endif
 
-  exe 'let langs = g:detectspelllang_langs.' . g:detectspelllang_program
+  let langs = g:detectspelllang_langs[g:detectspelllang_program]
   if empty(lines) || len(langs) < 2
     " default to first (=system) language
     let lang = langs[0]

--- a/plugin/detectspelllang.vim
+++ b/plugin/detectspelllang.vim
@@ -36,9 +36,9 @@ if !exists('g:detectspelllang_langs')
   let v_lang = matchstr(v:lang, '^\a\a_\a\a')
   let dicts = systemlist(g:detectspelllang_aspell ? 'aspell dicts' : 'hunspell -D')
   let s:langs = filter(dicts, 'v:val is# "'. 'en' . '"' . '||' . 'v:val is# "' . v_lang . '"')
-  exe 'let g:detectspelllang_langs.g:detectspelllang_program = ' . 's:langs'
+  let g:detectspelllang_langs[g:detectspelllang_program] = s:langs
   unlet s:langs
-  if len(g:detectspelllang_langs.g:detectspelllang_program) < 2
+  if len(g:detectspelllang_langs[g:detectspelllang_program]) < 2
     echoerr 'DetectSpellLang: Please list at least two different languages in g:detectspelllang_langs.' . g:detectspelllang_program . '!'
     finish
   endif


### PR DESCRIPTION
Use `let x = dict[key]` syntax instead of `exe 'let x = dict.' . key`.
Cleaner, and work for any strange value of `key`.