### PR TITLE
Fix hunspell dicts detection

### DIFF
--- a/plugin/detectspelllang.vim
+++ b/plugin/detectspelllang.vim
@@ -34,10 +34,17 @@ if !exists('g:detectspelllang_langs')
   let g:detectspelllang_langs = {}
 
   let v_lang = matchstr(v:lang, '^\a\a_\a\a')
+  if !executable('sed')
+      let s:hunspell_dicts_cmd = 'hunspell -D |& sed "1,/AVAILABLE DICTIONARIES/d"'
+  else
+      " Not able to filter out the search path and section headers, hope they
+      " won't be recognized as dictionnary name…
+      let s:hunspell_dicts_cmd = 'hunspell -D'
+  endif
   let dicts = systemlist(
           \ g:detectspelllang_aspell ?
           \ 'aspell dicts' :
-          \ 'hunspell -D |& sed "1,/AVAILABLE DICTIONARIES/d"')
+          \ s:hunspell_dicts_cmd)
   let s:langs = filter(dicts, 'v:val =~# "en$" || v:val =~# "' . v_lang . '$"')
   let g:detectspelllang_langs[g:detectspelllang_program] = s:langs
   unlet s:langs

--- a/plugin/detectspelllang.vim
+++ b/plugin/detectspelllang.vim
@@ -34,8 +34,11 @@ if !exists('g:detectspelllang_langs')
   let g:detectspelllang_langs = {}
 
   let v_lang = matchstr(v:lang, '^\a\a_\a\a')
-  let dicts = systemlist(g:detectspelllang_aspell ? 'aspell dicts' : 'hunspell -D')
-  let s:langs = filter(dicts, 'v:val is# "'. 'en' . '"' . '||' . 'v:val is# "' . v_lang . '"')
+  let dicts = systemlist(
+          \ g:detectspelllang_aspell ?
+          \ 'aspell dicts' :
+          \ 'hunspell -D |& sed "1,/AVAILABLE DICTIONARIES/d"')
+  let s:langs = filter(dicts, 'v:val =~# "en$" || v:val =~# "' . v_lang . '$"')
   let g:detectspelllang_langs[g:detectspelllang_program] = s:langs
   unlet s:langs
   if len(g:detectspelllang_langs[g:detectspelllang_program]) < 2

--- a/plugin/detectspelllang.vim
+++ b/plugin/detectspelllang.vim
@@ -35,7 +35,7 @@ if !exists('g:detectspelllang_langs')
 
   let v_lang = matchstr(v:lang, '^\a\a_\a\a')
   if !executable('sed')
-      let s:hunspell_dicts_cmd = 'hunspell -D |& sed "1,/AVAILABLE DICTIONARIES/d"'
+      let s:hunspell_dicts_cmd = 'hunspell -D 2>&1 | sed "1,/AVAILABLE DICTIONARIES/d"'
   else
       " Not able to filter out the search path and section headers, hope they
       " won't be recognized as dictionnary name…


### PR DESCRIPTION
`hunspell -D` output is really different from `aspell dicts`.  It
outputs (1) a search path and (2) a list of paths to dictionary files.

(1) use a sed call to clean `hunspell -D` output
(2) change the filter to match at the end, whatever be on the beginning
of the line.

`hunspell -d <dict>` supports having a full path in argument, so we can
keep the full path.

To be merged after #7